### PR TITLE
Add missing python-multipart dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi-cli>=0.0.8",
     "jinja2>=3.1.6",
     "python-decouple>=3.8",
+    "python-multipart>=0.0.20",
     "urllib3>=2.5.0",
 ]
 


### PR DESCRIPTION
Following the `README.md` and running `uv run fastapi dev src/api/main.py` in the `jeff-dev` branch gives me

```
RuntimeError: Form data requires "python-multipart" to be installed.
You can install "python-multipart" with:

pip install python-multipart
```

This change makes it so that the `uv sync` step installs python-multipart.