### PR TITLE
Add missing httpx dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ packages = ["src"]
 
 [dependency-groups]
 dev = [
+    "httpx>=0.28.1",
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "ruff>=0.12.7",


### PR DESCRIPTION
I couldn't run the tests without adding httpx first, a transitive dependency:
> RuntimeError: The starlette.testclient module requires the httpx package to be installed.